### PR TITLE
Bugfixes and compatibility with newer OpenSSL versions

### DIFF
--- a/ssl-tool-generate-csr-key.sh
+++ b/ssl-tool-generate-csr-key.sh
@@ -7,28 +7,31 @@
 CN="${1}"
 
 # Get the certificate info in plaintext format
-CERT_DATA=$(openssl s_client -servername "${CN}" \
-              -connect "${CN}":443  2>&1 < /dev/null \
-                | openssl x509 -noout -text \
+CERT_DATA=$(
+              openssl s_client -servername "${CN}" \
+                -connect "${CN}":443  2>&1 < /dev/null \
+                  | openssl x509 -noout -text \
           )
 
 # Let's try to build the  [ dn ] info
-DN=$(echo -e "${CERT_DATA}" \
-       | grep 'Subject:' \
-       | perl -pe 's/^\s+Subject:\s//' \
-       | perl -pe 's/\, ([A-Z]{1,2}=)/\n\1/g' \
+DN=$(
+      echo -e "${CERT_DATA}" \
+        | grep 'Subject:' \
+        | perl -pe 's/^\s+Subject:\s//' \
+        | perl -pe 's/\, ([A-Z]{1,2}=)/\n\1/g' \
    )
     
 # [ alt_names ] info
-ARRAY=( $(echo -e "${CERT_DATA}" \
-            | grep 'DNS:' \
-            | perl -pe 's/^\s+DNS://g' \
-            | perl -pe 's/, DNS:/\n/g' \
+ARRAY=( 
+         $(echo -e "${CERT_DATA}" \
+              | grep 'DNS:' \
+              | perl -pe 's/^\s+DNS://g' \
+              | perl -pe 's/, DNS:/\n/g' \
          )
-       )
+      )
 
 # File name standard (example.com -> example_com)
-FN="$(echo ${CN} | perl -pe 's/\./_/g')"
+FN=$(echo "${CN}" | perl -pe 's/\./_/g')
 
 # Parse the data for [ alt_names ]
 for ((i = 0; i < ${#ARRAY[@]}; ++i));

--- a/ssl-tool-generate-csr-key.sh
+++ b/ssl-tool-generate-csr-key.sh
@@ -48,7 +48,7 @@ echo "**** Now verify, then copy and paste the following to generate .csr and .k
 echo "*********************************************************************************"
 echo
 
-echo -en "
+echo -e "
 openssl req -new -sha256 -nodes -out ${FN}.csr -newkey rsa:2048 -keyout ${FN}.key -config <(
 cat <<-EOF
 [req]

--- a/ssl-tool-generate-csr-key.sh
+++ b/ssl-tool-generate-csr-key.sh
@@ -15,23 +15,27 @@ CERT_DATA=$(
 
 # Let's try to build the  [ dn ] info
 DN=$(
-      echo -e "${CERT_DATA}" \
-        | grep 'Subject:' \
-        | perl -pe 's/^\s+Subject:\s//' \
-        | perl -pe 's/\, ([A-Z]{1,2}=)/\n\1/g' \
+       echo -e "${CERT_DATA}" \
+         | grep 'Subject:' \
+         | perl -pe 's/^\s+Subject:\s//' \
+         | perl -pe 's/\, ([A-Z]{1,2}=)/\n\1/g' \
    )
     
 # [ alt_names ] info
 ARRAY=( 
-         $(echo -e "${CERT_DATA}" \
-              | grep 'DNS:' \
-              | perl -pe 's/^\s+DNS://g' \
-              | perl -pe 's/, DNS:/\n/g' \
+         $(
+             echo -e "${CERT_DATA}" \
+               | grep 'DNS:' \
+               | perl -pe 's/^\s+DNS://g' \
+               | perl -pe 's/, DNS:/\n/g' \
          )
       )
 
 # File name standard (example.com -> example_com)
-FN=$(echo "${CN}" | perl -pe 's/\./_/g')
+FN=$(
+       echo "${CN}" \
+         | perl -pe 's/\./_/g'
+   )
 
 # Parse the data for [ alt_names ]
 for ((i = 0; i < ${#ARRAY[@]}; ++i));

--- a/ssl-tool-generate-csr-key.sh
+++ b/ssl-tool-generate-csr-key.sh
@@ -15,12 +15,12 @@ CERT_DATA=$(openssl s_client -servername "${CN}" \
 # Let's try to build the  [ dn ] info
 DN=$(echo -e "${CERT_DATA}" | grep "Subject:" \
     | perl -pe 's/^\s+Subject:\s//' \
-    | perl -pe 's/\, /\n\1/g')
+    | perl -pe 's/\, ([A-Z]{1,2}=)/\n\1/g')
     
 # [ alt_names ] info
 ARRAY=( $(echo -e "${CERT_DATA}" \
     | grep "DNS:" \
-    | perl -pe 's/^ +DNS://g' \
+    | perl -pe 's/^\s+DNS://g' \
     | perl -pe 's/, DNS:/\n/g') )
 
 FN="$(echo ${CN} | perl -pe 's/\./_/g')"

--- a/ssl-tool-generate-csr-key.sh
+++ b/ssl-tool-generate-csr-key.sh
@@ -18,7 +18,7 @@ DN=$(
        echo -e "${CERT_DATA}" \
          | grep 'Subject:' \
          | perl -pe 's/^\s+Subject:\s//' \
-         | perl -pe 's/\, ([A-Z]{1,2}=)/\n\1/g' \
+         | perl -pe 's/\, ([A-Z]{1,2}\s?=)/\n\1/g' \
    )
     
 # [ alt_names ] info


### PR DESCRIPTION
Fixed some bugs and adapted for newer versions of OpenSSL that add an extra space before the equals sign, e.g. `OU =` vs `OU=`